### PR TITLE
chore: forgive stack deletion if stack not found

### DIFF
--- a/Runner-Image/scripts/delete.sh
+++ b/Runner-Image/scripts/delete.sh
@@ -14,12 +14,15 @@ pulumi version
 pulumiLogin
 
 echo -e "\n>>> Selecting Pulumi Stack...\n"
-pulumi stack select $ADE_ENVIRONMENT_NAME
+if pulumi stack select $ADE_ENVIRONMENT_NAME; then
+    echo -e "\n>>> Setting Pulumi Config...\n"
+    export PULUMI_CONFIG_FILE=$ADE_STORAGE/Pulumi.$ADE_ENVIRONMENT_NAME.yaml
+    echo $PULUMI_CONFIG_FILE
+    cat $PULUMI_CONFIG_FILE
 
-echo -e "\n>>> Setting Pulumi Config...\n"
-export PULUMI_CONFIG_FILE=$ADE_STORAGE/Pulumi.$ADE_ENVIRONMENT_NAME.yaml
-echo $PULUMI_CONFIG_FILE
-cat $PULUMI_CONFIG_FILE
-
-echo -e "\n>>> Running Pulumi Destroy...\n"
-pulumi destroy --refresh --yes --config-file $PULUMI_CONFIG_FILE
+    echo -e "\n>>> Running Pulumi Destroy...\n"
+    pulumi destroy --refresh --yes --config-file $PULUMI_CONFIG_FILE
+else
+    # forgive if stack not found
+    echo -e "\n>>> Pulumi Stack not found. Stack deployment might be failed, complete without deleting stack.\n"
+fi


### PR DESCRIPTION
## tl;dr;

Sometimes `delete.sh` fails to recover, making it impossible to delete Azure Deployment Environments (ADE). This Pull Request adds the ability to skip deleting the Pulumi stack if it can't be found.

## Description of the issue

When ADE fails to create resources with Pulumi for some reason, the Pulumi stack won't be created. However, deleting the ADE triggers the execution of `delete.sh`, which always fails with the following error message:

```
"message": "Operation failed with exit code UnknownError! Additional Error Details: ERROR: 'null' is not a valid ID\nerror: no stack named 'foobar' found"
```

If the deployment is recreated successfully, then `delete.sh` will succeed without this PR. However, there is no chance to delete the ADE otherwise, as there are no Azure roles to modify ADEs created by other users. There are only `Deployment Environments User` and `Deployment Environments Reader` roles, but no admin right to control other users' ADEs.

## How this PR works

If there is no stack, then it skips the Pulumi stack deletion. Since Pulumi can't do anything if the stack is not found, there are no side effects with this change.