### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -8,6 +8,11 @@ env:
   registryName: ${{ vars.REGISTRY_NAME }}
   repositoryName: ${{ vars.REPOSITORY_NAME }}
   tag: ${{ vars.TAG }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 
 jobs:
 
@@ -16,16 +21,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: 'Az CLI login'
       uses: azure/login@v2
       with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          
+          client-id: ${{ steps.esc-secrets.outputs.AZURE_CLIENT_ID }}
+          tenant-id: ${{ steps.esc-secrets.outputs.AZURE_TENANT_ID }}
+          subscription-id: ${{ steps.esc-secrets.outputs.AZURE_SUBSCRIPTION_ID }}
+
     - name: 'Login to Specified ACR'
       run: az acr login -n $registryName
-      
+
     - uses: actions/checkout@v3
     - name: Build the Docker Image
       run: docker build ./Runner-Image --file Dockerfile --tag "$registryName.azurecr.io/$repositoryName:$tag"


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
