### PR TITLE
Update to base image `4.3.0-preview`

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -11,13 +11,17 @@ You are tasked with creating a new release of the Pulumi Azure Deployment Enviro
 3. Increment the minor version (e.g., v0.1.0 → v0.2.0) unless the user specifies otherwise
 4. Confirm the new version number with the user using AskUserQuestion
 
-## Step 2: Update Runner Image Tags
+## Step 2: Prepare Files for Release
 
-1. Find all `environment.yaml` files in the `Environments/` directory using Glob
-2. For each file, update the `runner:` field to use the new version tag
+1. Update the base image tag in `Runner-Image/Dockerfile`:
+   - Find the `ARG BASE_IMAGE_TAG=` line
+   - Update to the latest available version from mcr.microsoft.com/deployment-environments/runners/core
+   - Check https://mcr.microsoft.com/v2/deployment-environments/runners/core/tags/list or use Docker Hub to find the latest version (not "latest")
+2. Find all `environment.yaml` files in the `Environments/` directory using Glob
+3. For each file, update the `runner:` field to use the new version tag
    - Current format is typically: `pulumi/azure-deployment-environments:latest` or `pulumi/azure-deployment-environments:v0.1.0`
    - Update to: `pulumi/azure-deployment-environments:<new-version>`
-3. Use the Edit tool to update each file
+4. Use the Edit tool to update each file
 
 ## Step 3: Create Release Preparation PR
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,47 @@
+---
+description: Create a new release of the Pulumi runner image
+---
+
+You are tasked with creating a new release of the Pulumi Azure Deployment Environments runner image. Follow these steps:
+
+## Step 1: Determine Next Version Number
+
+1. Use `git tag --list 'v*' --sort=-version:refname` to get all existing version tags
+2. Parse the latest version tag (e.g., v0.1.0)
+3. Increment the minor version (e.g., v0.1.0 → v0.2.0) unless the user specifies otherwise
+4. Confirm the new version number with the user using AskUserQuestion
+
+## Step 2: Update Runner Image Tags
+
+1. Find all `environment.yaml` files in the `Environments/` directory using Glob
+2. For each file, update the `runner:` field to use the new version tag
+   - Current format is typically: `pulumi/azure-deployment-environments:latest` or `pulumi/azure-deployment-environments:v0.1.0`
+   - Update to: `pulumi/azure-deployment-environments:<new-version>`
+3. Use the Edit tool to update each file
+
+## Step 3: Create Release Preparation PR
+
+1. Create a new branch named `release/v<new-version>` (e.g., `release/v0.2.0`)
+2. Commit the environment.yaml changes with message: "Prepare release v<new-version>"
+3. Push the branch to origin
+4. Create a PR titled "Prepare Release v<new-version>" with a body that:
+   - Lists the changes since the last release
+   - Mentions this prepares the release
+   - Notes that merging will NOT trigger the release (that happens in step 3)
+5. Note that opening a PR has the effect of doing a dry-run build of the docker image.
+
+## Step 4: Tag and Push to Trigger Release
+
+1. After the PR is merged (wait for user confirmation or check PR status)
+2. Ensure you're on the main branch and pull the latest changes
+3. Create an annotated git tag: `git tag -a v<new-version> -m "Release v<new-version>"`
+4. Push the tag: `git push origin v<new-version>`
+5. Inform the user that this will trigger the `docker-hub.yaml` workflow
+6. Provide a link to monitor the workflow run
+
+## Important Notes
+
+- ALWAYS confirm the version number with the user before proceeding
+- ALWAYS wait for user confirmation before pushing the tag in step 3
+- The docker-hub.yaml workflow will automatically build and push to Docker Hub when a version tag is pushed
+- After successful release, suggest updating issue #3 with the release information

--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -1,0 +1,80 @@
+name: Docker Hub
+
+on:
+  pull_request:
+    paths:
+      - 'Runner-Image/**'
+      - '.github/workflows/docker-hub.yaml'
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  IMAGE_NAME: pulumi/azure-deployment-environments
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build Docker image (PR - dry run)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v5
+        with:
+          context: ./Runner-Image
+          file: ./Runner-Image/Dockerfile
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Login to Docker Hub
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          username: pulumi
+          password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
+
+      - name: Build and push Docker image (tag)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v5
+        with:
+          context: ./Runner-Image
+          file: ./Runner-Image/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Runner-Image/Dockerfile
+++ b/Runner-Image/Dockerfile
@@ -11,6 +11,11 @@ ARG IMAGE_VERSION
 # Metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 
+# install python (required by newer core images)
+RUN apk add python3 || \
+    (echo "Failed to install python3 with apk, trying with tdnf" && \
+    tdnf install -y python3)
+
 # install pulumi
 RUN apk add curl || \
     (echo "Failed to install curl with apk, trying with tdnf" && \

--- a/Runner-Image/Dockerfile
+++ b/Runner-Image/Dockerfile
@@ -1,26 +1,17 @@
 # Copyright 2024, Pulumi Corporation.
 
 ARG BASE_IMAGE=mcr.microsoft.com/deployment-environments/runners/core
-ARG IMAGE_VERSION=latest
+ARG BASE_IMAGE_TAG=4.3.0-preview
 
-FROM ${BASE_IMAGE}:${IMAGE_VERSION}
+FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}
 WORKDIR /
 
-ARG IMAGE_VERSION
+ARG BASE_IMAGE_TAG
 
 # Metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 
-# install python (required by newer core images)
-RUN apk add python3 || \
-    (echo "Failed to install python3 with apk, trying with tdnf" && \
-    tdnf install -y python3)
-
-# install pulumi
-RUN apk add curl || \
-    (echo "Failed to install curl with apk, trying with tdnf" && \
-    tdnf install -y tar gzip && \
-    tdnf install -y curl)
+# install pulumi (base image already contains python3, curl, tar, gzip)
 RUN curl -fsSL https://get.pulumi.com | sh
 ENV PATH="${PATH}:/root/.pulumi/bin"
 RUN pulumi plugin install resource azure-native

--- a/Runner-Image/Dockerfile
+++ b/Runner-Image/Dockerfile
@@ -11,7 +11,11 @@ ARG BASE_IMAGE_TAG
 # Metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 
-# install pulumi (base image already contains python3, curl, tar, gzip)
+# install pulumi
+RUN apk add curl || \
+    (echo "Failed to install curl with apk, trying with tdnf" && \
+    tdnf install -y tar gzip && \
+    tdnf install -y curl)
 RUN curl -fsSL https://get.pulumi.com | sh
 ENV PATH="${PATH}:/root/.pulumi/bin"
 RUN pulumi plugin install resource azure-native


### PR DESCRIPTION
## Summary
- Updates Dockerfile to use explicit base image versioning (`4.3.0-preview` instead of `latest`)
- Renames `IMAGE_VERSION` to `BASE_IMAGE_TAG` for clarity
- Adds GitHub Actions workflow for automated Docker Hub publishing
- Adds `/release` slash command to streamline the release process

## Changes

### Dockerfile (`Runner-Image/Dockerfile`)
- Replaces `ARG IMAGE_VERSION=latest` with `ARG BASE_IMAGE_TAG=4.3.0-preview` for explicit version pinning
- Updates `FROM` statement to use `${BASE_IMAGE}:${BASE_IMAGE_TAG}` for consistency
- Renames build arg from `IMAGE_VERSION` to `BASE_IMAGE_TAG` to better reflect its purpose

### Docker Hub Workflow (`.github/workflows/docker-hub.yaml`)
Adds automated Docker image building and publishing:
- **On PRs** that modify `Runner-Image/**`: Performs a dry-run build to validate Dockerfile changes
- **On version tags** (`v*`): Builds and pushes images to Docker Hub (`pulumi/azure-deployment-environments`)
- Uses Pulumi ESC to securely fetch Docker Hub credentials via OIDC authentication
- Implements proper Docker image tagging (semver, latest)
- Leverages GitHub Actions cache for faster builds

### Release Command (`.claude/commands/release.md`)
Adds a comprehensive `/release` slash command that automates the release workflow:
1. **Version Management**: Determines next version from git tags with user confirmation
2. **File Updates**: Updates base image tag in Dockerfile and runner references in all `environment.yaml` files
3. **PR Creation**: Creates a release preparation PR with all necessary changes
4. **Release Publishing**: Guides through tagging and pushing to trigger the Docker Hub workflow

## Test Plan
1. ✅ PR build validates the Dockerfile builds successfully with explicit versioning
2. After merge, create a version tag (e.g., `v1.0.0`) to trigger Docker Hub publishing
3. Verify published image works with ADE deployments
4. Test the `/release` command for future releases

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)