### PR TITLE
Fix Docker Hub login username

### DIFF
--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -64,7 +64,7 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@v3
         with:
-          username: pulumi
+          username: pulumibot
           password: ${{ steps.esc-secrets.outputs.DOCKER_HUB_PASSWORD }}
 
       - name: Build and push Docker image (tag)


### PR DESCRIPTION
## Summary
- Fix Docker Hub authentication failure by changing username from `pulumi` to `pulumibot`

## Details
The release workflow was failing at the Docker Hub login step with an authentication error. The correct username for Docker Hub is `pulumibot`, not `pulumi`.

This fixes the error seen in https://github.com/pulumi/azure-deployment-environments/actions/runs/18662945072/job/53207513594

🤖 Generated with [Claude Code](https://claude.com/claude-code)